### PR TITLE
Secure WebSocket (wss://) support

### DIFF
--- a/src/main/scala/org/jfarcand/wcs/Websocket.scala
+++ b/src/main/scala/org/jfarcand/wcs/Websocket.scala
@@ -64,7 +64,7 @@ case class WebSocket(o: Options,
    */
   def open(s: String): WebSocket = {
 
-    if (!s.startsWith("ws://")) throw new RuntimeException("Invalid Protocol. Only WebSocket ws:// supported" + s)
+    if (!s.startsWith("ws://") && !s.startsWith("wss://")) throw new RuntimeException("Invalid Protocol. Only WebSocket ws:// or wss:// supported" + s)
 
     val b = new WebSocketUpgradeHandler.Builder
     if (o != null) {


### PR DESCRIPTION
Hello Jeanfrancois,

here's a minor patch to make WCS work with secure WebSockets (`wss://`). All I had to do, besides patching the URL check, was

```
WebSocket.config.setSSLContext(...)
```

Actually I thought there was more to do ;-)
