### PR TITLE
scala 2.11 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+logs
+project/project
+project/target
+target
+tmp
+.history
+dist
+/.idea
+/*.iml
+META-INF
+/out
+/.idea_modules
+/.classpath
+/.project
+/RUNNING_PID
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.9.1</artifactId>
-            <version>1.6.1</version>
+            <artifactId>scalatest_2.11</artifactId>
+            <version>2.2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>2.9.1</version>
+            <version>2.11.7</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -253,7 +253,6 @@
                         <jvmArg>-Xmx384m</jvmArg>
                     </jvmArgs>
                     <args>
-                        <arg>-target:jvm-1.5</arg>
                         <arg>-deprecation</arg>
                     </args>
                     <launchers>
@@ -279,6 +278,7 @@
             <plugin>
                 <groupId>org.scala-tools</groupId>
                 <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.2</version>
             </plugin>
             <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -324,8 +324,8 @@
     <properties>
         <distMgmtSnapshotsUrl>http://oss.sonatype.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
         <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
-        <source.property>1.7</source.property>
-        <target.property>1.7</target.property>
+        <source.property>1.8</source.property>
+        <target.property>1.8</target.property>
     </properties>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
                 <version>2.8.1</version>
                 <configuration>
                     <aggregate>true</aggregate>
-                    <source>1.6</source>
+                    <source>1.5</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>
@@ -286,7 +286,7 @@
             <version>2.8.1</version>
             <configuration>
                 <aggregate>true</aggregate>
-                <source>1.6</source>
+                <source>1.5</source>
                 <encoding>UTF-8</encoding>
                 <maxmemory>1g</maxmemory>
                 <links>
@@ -324,8 +324,8 @@
     <properties>
         <distMgmtSnapshotsUrl>http://oss.sonatype.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
         <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
-        <source.property>1.8</source.property>
-        <target.property>1.8</target.property>
+        <source.property>1.5</source.property>
+        <target.property>1.5</target.property>
     </properties>
 </project>
 

--- a/src/test/scala/org/jfarcand/wcs/test/BaseTest.scala
+++ b/src/test/scala/org/jfarcand/wcs/test/BaseTest.scala
@@ -9,40 +9,32 @@ import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
 import org.eclipse.jetty.server.{ Request, Server }
 
 import org.scalatest.{ FlatSpec, BeforeAndAfterAll }
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
-abstract class BaseTest extends Server with FlatSpec with BeforeAndAfterAll with ShouldMatchers {
+trait BaseTest extends FlatSpec with BeforeAndAfterAll with Matchers {
+
+  protected val server: Server = new Server()
   protected final val log: Logger = LoggerFactory.getLogger(classOf[BaseTest])
   protected var port1: Int = 0
   private var _connector: SelectChannelConnector = null
 
-  override def beforeAll(configMap: Map[String, Any]) = {
-    setUpGlobal
-  }
-
-  override def afterAll(configMap: Map[String, Any]) = {
-    tearDownGlobal
-  }
-
-  def setUpGlobal = {
+  override protected def beforeAll(): Unit =  {
     port1 = findFreePort
     _connector = new SelectChannelConnector
     _connector.setPort(port1)
-    addConnector(_connector)
+    server.addConnector(_connector)
     val _wsHandler: BaseTest#WebSocketHandler = getWebSocketHandler
-    setHandler(_wsHandler)
-    start
+    server.setHandler(_wsHandler)
+    server.start()
     log.info("Local HTTP server started successfully")
   }
 
-  def tearDownGlobal = {
-    stop
-  }
+  override protected def afterAll(): Unit = server.stop()
 
   abstract class WebSocketHandler extends HandlerWrapper with WebSocketFactory.Acceptor {
 
     def getWebSocketFactory: WebSocketFactory = {
-      return _webSocketFactory
+      _webSocketFactory
     }
 
     override def handle(target: String, baseRequest: Request, request: HttpServletRequest, response: HttpServletResponse): Unit = {
@@ -51,7 +43,7 @@ abstract class BaseTest extends Server with FlatSpec with BeforeAndAfterAll with
     }
 
     def checkOrigin(request: HttpServletRequest, origin: String): Boolean = {
-      return true
+      true
     }
 
     private final val _webSocketFactory: WebSocketFactory = new WebSocketFactory(this, 32 * 1024)
@@ -61,16 +53,16 @@ abstract class BaseTest extends Server with FlatSpec with BeforeAndAfterAll with
     var socket: ServerSocket = null
     try {
       socket = new ServerSocket(0)
-      return socket.getLocalPort
+      socket.getLocalPort
     } finally {
       if (socket != null) {
-        socket.close
+        socket.close()
       }
     }
   }
 
   protected def getTargetUrl: String = {
-    "ws://127.0.0.1:" + port1;
+    "ws://127.0.0.1:" + port1
   }
 
   def getWebSocketHandler: BaseTest#WebSocketHandler

--- a/src/test/scala/org/jfarcand/wcs/test/WSSTest.scala
+++ b/src/test/scala/org/jfarcand/wcs/test/WSSTest.scala
@@ -1,8 +1,30 @@
 package org.jfarcand.wcs.test
 
-/**
- * Created by svinci on 12/08/15.
- */
-class WSSTest {
+import java.util.concurrent.CountDownLatch
+
+import org.jfarcand.wcs.{MessageListener, WebSocket}
+import org.scalatest.{Matchers, FlatSpec}
+
+class WSSTest extends FlatSpec with Matchers {
+
+  it should "receive three messages" in {
+    val w = WebSocket()
+    val latch: CountDownLatch = new CountDownLatch(3)
+    var messages: Seq[String] = Seq()
+    w open "wss://stream.pushbullet.com/websocket/wHDLQQ4cWz7uH89MjpKh47dcc8AhyFrd" listener new MessageListener {
+      override def onMessage(message: String): Unit = {
+        println(message)
+        messages = messages ++ Seq(message)
+        latch.countDown()
+      }
+      override def onOpen: Unit = println("open connection")
+      override def onClose: Unit = println("close connection")
+      override def onClose(code: Int, reason: String): Unit = println(s"close connection, code ${code.toString}. reason: $reason")
+      override def onError(t: Throwable): Unit = t.printStackTrace()
+      override def onMessage(message: Array[Byte]): Unit = onMessage(new String(message))
+    }
+    latch.await()
+    assert(messages.size == 3)
+  }
 
 }

--- a/src/test/scala/org/jfarcand/wcs/test/WSSTest.scala
+++ b/src/test/scala/org/jfarcand/wcs/test/WSSTest.scala
@@ -1,0 +1,8 @@
+package org.jfarcand.wcs.test
+
+/**
+ * Created by svinci on 12/08/15.
+ */
+class WSSTest {
+
+}


### PR DESCRIPTION
Compiled with scala 2.11, now it's ready to be published.
All tests passed.
This pull request is made from issue: #16 

Now I don't know if I'm not using it right... but I think it doesn't have WSS suport (secure websocket). I think it would be awesome to add it, but I really don't know how to. So I couldn't implement it.
I can do it if you point me in any direction.
Thank you very much!